### PR TITLE
use other cdn that supports ssl

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <title>道路中心線ベクトルタイル表示サンプル</title>
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css"/>
-    <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet.css"/>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet.js"></script>
     <script src="./leaflet-hash.js"></script>
     <script src="./TileLayer.GeoJSON.js"></script>
     <style>


### PR DESCRIPTION
cdn.leafletjs.comはhttpsをサポートしていないので、
httpsをサポートしたcdnを使うようにしました。
ただし、Firefoxではタイル自体がhttpで配布されているため取得はできません。
Chromeでは見ることができます。
https://smellman.github.io/vector-tile-experiment/#17/36.10347/140.08741
